### PR TITLE
Workaround to allow custom currencies for microsites in ecommerce

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import logging
 
 import waffle
-from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Count, Q
 from django.utils.timezone import now, timedelta
@@ -16,6 +15,7 @@ from ecommerce.core.constants import (
 )
 from ecommerce.courses.publishers import LMSPublisher
 from ecommerce.extensions.catalogue.utils import generate_sku
+from ecommerce.edunext.conf import settings
 
 logger = logging.getLogger(__name__)
 Category = get_model('catalogue', 'Category')

--- a/ecommerce/edunext/conf.py
+++ b/ecommerce/edunext/conf.py
@@ -1,0 +1,47 @@
+"""
+This file implements a class which is a handy utility to make any
+call to the settings completely site aware by replacing the:
+
+from django.conf import settings
+
+with:
+
+from ecommerce.edunext.conf import settings
+
+"""
+from threadlocals.threadlocals import get_current_request
+
+from django.conf import settings as base_settings
+
+from ecommerce.edunext.models import SiteOptions
+
+
+class SiteAwareSettings(object):
+    """
+    This class is a proxy object of the settings object from django.
+    It will try to get a value from the microsite and default to the
+    django settings
+    """
+
+    def get_current_request_site_options(self):
+        """
+        This method retrieves the edunext options for current request site
+        """
+        site = get_current_request().site
+        try:
+            options = site.siteoptions.options_blob
+        except SiteOptions.DoesNotExist:
+            # May be log some message
+            options = {}
+
+        return options
+
+    def __getattr__(self, name):
+        current_site_options = self.get_current_request_site_options()
+        try:
+            return current_site_options.get(name, getattr(base_settings, name))
+        except KeyError:
+            return getattr(base_settings, name)
+
+
+settings = SiteAwareSettings()  # pylint: disable=invalid-name

--- a/ecommerce/edunext/models.py
+++ b/ecommerce/edunext/models.py
@@ -6,6 +6,8 @@ This file contains models used by edunext for customizing the ecommerce service.
 import collections
 
 from django.db import models
+from django.db.models.signals import pre_delete
+from django.contrib.sites.models import Site
 from django.utils.translation import ugettext_lazy as _
 from jsonfield.fields import JSONField
 
@@ -33,3 +35,19 @@ class SiteOptions(models.Model):
         Meta class for SiteOptions model
         """
         verbose_name_plural = "SiteOptions"
+
+    def save(self, *args, **kwargs):
+        # Clear Site cache upon SiteOptions changed
+        Site.objects.clear_cache()
+        super(SiteOptions, self).save(*args, **kwargs)
+
+
+def clear_site_cache(sender, **kwargs):
+    # pylint: disable=unused-argument
+    """
+    Clear the cache (if primed) each time a site is saved or deleted.
+    """
+    Site.objects.clear_cache()
+
+
+pre_delete.connect(clear_site_cache, sender=SiteOptions)

--- a/ecommerce/edunext/tests/test_conf.py
+++ b/ecommerce/edunext/tests/test_conf.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from mock import MagicMock, patch
+
+from django.test.utils import override_settings
+from django.contrib.sites.models import Site
+
+from ecommerce.tests.testcases import TestCase
+from ecommerce.edunext.models import SiteOptions
+from ecommerce.edunext.conf import settings as SiteSettings
+
+
+def _make_site(blob_str=None, site_id=1):
+    """
+    Returns a site object. If blob_str is passed, a SiteOptions object
+    related to the site is created or updated with the blob, otherwise,
+    existent SiteOptions object for the site is deleted
+    """
+    site = Site.objects.get(id=site_id)
+
+    if blob_str is not None:
+        obj, _ = SiteOptions.objects.get_or_create(
+            site=site
+        )
+        obj.options_blob = blob_str
+        obj.save()
+    else:
+        SiteOptions.objects.filter(site=site).delete()
+
+    return site
+
+
+class EdunextConfTests(TestCase):
+    """
+    Test for Edunext site aware configurations
+    """
+
+    @override_settings(OSCAR_DEFAULT_CURRENCY="CAD")
+    @patch("ecommerce.edunext.conf.get_current_request")
+    def test_conf_without_siteoptions(self, get_current_request_mock):
+        request_mock = MagicMock()
+        request_mock.site = _make_site()
+        get_current_request_mock.return_value = request_mock
+        self.assertEqual(SiteSettings.OSCAR_DEFAULT_CURRENCY, "CAD")
+
+    @override_settings(OSCAR_DEFAULT_CURRENCY="COP")
+    @patch("ecommerce.edunext.conf.get_current_request")
+    def test_conf_with_siteoptions_no_overide(self, get_current_request_mock):
+        request_mock = MagicMock()
+        site_options = {
+            "ANY_OTHER_SETTING": "any_value"
+        }
+        request_mock.site = _make_site(site_options)
+        get_current_request_mock.return_value = request_mock
+        self.assertEqual(SiteSettings.OSCAR_DEFAULT_CURRENCY, "COP")
+
+    @override_settings(OSCAR_DEFAULT_CURRENCY="USD")
+    @patch("ecommerce.edunext.conf.get_current_request")
+    def test_conf_with_siteoptions_overide(self, get_current_request_mock):
+        request_mock = MagicMock()
+        site_options = {
+            "OSCAR_DEFAULT_CURRENCY": "BRL"
+        }
+        request_mock.site = _make_site(site_options)
+        get_current_request_mock.return_value = request_mock
+        self.assertEqual(SiteSettings.OSCAR_DEFAULT_CURRENCY, "BRL")


### PR DESCRIPTION
Flushing django sites cache when saving a site options object

Adding a SiteAwareSettings class to enable site configuration overides per site

Using site aware settings to override OSCAR_DEFAULT_CURRENCY configuration

Removing debug flag!!

Removing site cache when deleting a SiteOptions object

Now pylint should be happy

Adding tests to make sure site aware settings are working correctly

@felipemontoya 