### PR TITLE
ju/ednx/E-02 Add ecommerce-extensions dependency.

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -201,6 +201,7 @@ TEMPLATES = [
                 'oscar.core.context_processors.metadata',
                 'ecommerce.core.context_processors.core',
                 'ecommerce.extensions.analytics.context_processors.analytics',
+                'ecommerce_extensions.tenant.context_processors.theme_options',
             ),
             'debug': True,  # Django will only display debug pages if the global DEBUG setting is set to True.
         }
@@ -318,6 +319,7 @@ LOCAL_APPS = [
     'ecommerce.enterprise',
     'ecommerce.management',
     'ecommerce.journals',  # TODO: journals dependency
+    'ecommerce_extensions.tenant.apps.TenantConfig',
 ]
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -20,6 +20,7 @@ djangorestframework
 djangorestframework-csv
 djangorestframework-datatables
 drf-extensions
+ecommerce-extensions
 edx-auth-backends
 edx-django-release-util
 edx-django-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,12 +44,13 @@ django-threadlocals==0.10  # via -r requirements/base.in
 django-treebeard==4.3.1   # via django-oscar
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django-widget-tweaks==1.4.8  # via django-oscar
-django==2.2.16            # via -r requirements/base.in, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
+django==2.2.16            # via -r requirements/base.in, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, ecommerce-extensions, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-datatables==0.5.2  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
 drf-extensions==0.6.0     # via -r requirements/base.in
 drf-jwt==1.14.0           # via -c requirements/pins.txt, edx-drf-extensions
+ecommerce-extensions==0.1.0  # via -r requirements/base.in
 edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.4.2  # via -r requirements/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.in
@@ -66,7 +67,7 @@ idna==2.9                 # via requests
 isodate==0.6.0            # via zeep
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
-jsonfield2==3.0.3         # via -c requirements/pins.txt, -r requirements/base.in
+jsonfield2==3.0.3         # via -c requirements/pins.txt, -r requirements/base.in, ecommerce-extensions
 kombu==3.0.37             # via celery
 libsass==0.9.2            # via -r requirements/base.in, django-libsass
 lxml==4.5.0               # via premailer, zeep

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -56,6 +56,7 @@ djangorestframework-datatables==0.5.2  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
 drf-extensions==0.6.0     # via -r requirements/base.txt
 drf-jwt==1.14.0           # via -c requirements/pins.txt, -r requirements/base.txt, edx-drf-extensions
+ecommerce-extensions==0.1.0  # via -r requirements/base.in
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.4.2  # via -r requirements/base.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.txt


### PR DESCRIPTION
## Description
This dependency replaces the edunext django app https://github.com/eduNEXT/edunext-ecommerce/pull/24