### PR TITLE
fix: dashboard link and support link

### DIFF
--- a/ecommerce/templates/oscar/basket/basket.html
+++ b/ecommerce/templates/oscar/basket/basket.html
@@ -6,7 +6,7 @@
 {% load static %}
 
 {% block title %}
-{% trans 'Basket' as tmsg %}{{ tmsg | force_escape }}
+{% trans 'Basket' %}
 {% endblock title %}
 
 {% block navbar %}
@@ -45,12 +45,19 @@
                 {% if basket.is_empty %}
                     {% block emptybasket %}
                         <div class="depth depth-2 message-error-content">
-                            <h3>{% trans "Your basket is empty" as tmsg %}{{ tmsg | force_escape }}</h3>
-                            {% blocktrans asvar tmsg %}
-                                If you attempted to make a purchase, you have not been charged. Return to your {link_start}{link_middle}{homepage_url}dashboard{link_end} to try
-                                again, or {link_start}{homepage_url}{link_middle}contact {platform_name} Support{link_end}.
+                            <h3>{% trans "Your basket is empty" %}</h3>
+                            {% captureas dashboard_link_start %}
+                                <a class="basket-homepage-link" href="{{ homepage_url }}">
+                            {% endcaptureas %}
+
+                            {% captureas support_link_start %}
+                                <a class="basket-support-link" href="{{ support_url }}">
+                            {% endcaptureas %}
+
+                            {% blocktrans with link_end="</a>" %}
+                                If you attempted to make a purchase, you have not been charged. Return to your {{ dashboard_link_start }}{{homepage_url }}{{ link_end }} to try
+                                again, or {{ support_link_start }}contact {{ platform_name }} Support{{ link_end }}.
                             {% endblocktrans %}
-                            {% interpolate_html tmsg link_start='<a href="'|safe support_url=support_url|safe platform_name=platform_name|safe link_end='</a>'|safe homepage_url=homepage_url|safe link_middle='">'|safe %}
                         </div>
                     {% endblock %}
                 {% else %}


### PR DESCRIPTION
This PR was created in order to correct the bug that exists with the redirection of the dashboard and support links

stage: https://ecommerce.je-ecom.edunextstage.net/basket/
Actualmente en productivo.

![oscarpro](https://user-images.githubusercontent.com/66017940/123856787-1ff30f80-d8e7-11eb-86f1-576e3f435184.png)


https://shop.demo.edunext.io/basket/

En stage , así debería funcionar
![stage](https://user-images.githubusercontent.com/66017940/123858579-4ade6300-d8e9-11eb-822c-0e973894f9ee.png)

https://ecommerce.je-ecom.edunextstage.net/basket/






@felipemontoya, @magajh, @mariajgrimaldi , @jignaciopm, @MoisesGSalas 