### PR TITLE
E-16 fix: course_id in coupons edition

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 import datetime
 import json
 from decimal import Decimal
@@ -9,6 +8,7 @@ from uuid import uuid4
 import ddt
 import httpretty
 import mock
+import pytest
 import pytz
 from django.test import RequestFactory
 from django.urls import reverse
@@ -712,6 +712,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         self.assertEqual(voucher_range.catalog_query, data['catalog_query'])
         self.assertEqual(voucher_range.course_seat_types, data['course_seat_types'][0])
 
+    @pytest.mark.skip(reason="tests a behavior of coupon enterprise that is not used in edunext")
     def test_update_catalog_type(self):
         """Test updating dynamic range values deletes catalog."""
         voucher_range, data = self._get_voucher_range_with_updated_dynamic_catalog_values()
@@ -719,6 +720,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         self.assertEqual(voucher_range.catalog_query, data['catalog_query'])
         self.assertEqual(voucher_range.course_seat_types, data['course_seat_types'][0])
 
+    @pytest.mark.skip(reason="tests a behavior of coupon enterprise that is not used in edunext")
     def test_update_course_catalog_coupon(self):
         """
         Test that on updating a coupon as course catalog coupon with course
@@ -761,8 +763,8 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         }
 
         logger_name = 'ecommerce.core.utils'
-        expected_logger_message = 'Failed to create Range. Either catalog_query or course_catalog must be given ' \
-                                  'but not both and course_seat_types fields must be set.'
+        expected_logger_message = 'Failed to create Range. Catalog and dynamic catalog fields may not be set ' \
+                                  'in the same range.'
         with LogCapture(logger_name) as logger:
             response = self.get_response('PUT', path, data)
 

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -404,10 +404,10 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         # Remove catalog if switching from single course to dynamic query
         # In case of enterprise, range_data has enterprise data in it as enterprise is defined in UPDATABLE_RANGE_FIELDS
         # so Catalog should not be None if there is an enterprise is associated with it.
+        #
+        # eduNEXT: removing the catalog deletes the course from the coupon
+        # see: https://github.com/eduNEXT/edunext-ecommerce/pull/64
         if voucher_range.catalog:
-            if not enterprise_customer_data:
-                range_data['catalog'] = None
-
             if enterprise_customer_data and range_data.get('catalog_query'):
                 range_data['catalog'] = None
 


### PR DESCRIPTION
## Description

This change means that when editing coupons the coupon id is kept. Without this change when editing a coupon the id is deleted.

- [Problem explained](https://github.com/edx/ecommerce/pull/3524)
- [Jira](https://edunext.atlassian.net/browse/PS2021-1336?atlOrigin=eyJpIjoiZTQ2YWU4NmE4NTEzNDM1NDlhYmQ2MzNiNWQzMTk5ZjkiLCJwIjoiaiJ9)
- [Documentation](https://docs.google.com/document/d/1bPlYtyU79IvzlwZ0yVE9i71-CBJxJZ_DEdaIpHADePo/edit?usp=sharing)
- Juniper PR #64 

## How to test

- You need to have ecommerce.
In stack builder you can use this branch: https://github.com/eduNEXT/stack-builder/tree/mjh/add-ecommerce

- It is important that you have a course that is paid verified or professional (If you use stack-builder you can use Demostration Course).

- Then enter in ecommerce-link/coupons
(ej: http://localhost:18130/coupons in devstack)
(ej: http://ecommerce.limonero.edunext.link:8130/coupons in stack-builder)

- Create a coupon for that course (in organization I usually place edx)
- And then edit it.
- The expected behavior is that the "valid for course" field is not undefined.

## Before and After
Before
![Before](https://user-images.githubusercontent.com/35668326/135314603-260dbb87-24d7-48ea-9f2b-536949c039ad.png)

After
![After](https://user-images.githubusercontent.com/35668326/146582294-74b9295d-9cde-4dd4-975d-48f867de4897.png)


## About test modification

When the change was made in juniper the tests were not running, and these tests are trying to verify precisely the lines that were eliminated in coupons and enterprise configurations. You can try editing coupons as many times as you want and keep the correct seat type, the correct course and all the verifications that the tests for enterprise are supposed to do.

## Does that change affect some other process?
No, the edited function is only used in the coupon edition, also the commented lines refer to a coupon information in enterprise mode and currently in Edunext that type of coupon is not used.
