### PR TITLE
E-14 fix: dashboard link and support link

### DIFF
--- a/ecommerce/templates/oscar/basket/basket.html
+++ b/ecommerce/templates/oscar/basket/basket.html
@@ -47,8 +47,8 @@
                         <div class="depth depth-2 message-error-content">
                             <h3>{% trans "Your basket is empty" as tmsg %}{{ tmsg | force_escape }}</h3>
                             {% blocktrans asvar tmsg %}
-                                If you attempted to make a purchase, you have not been charged. Return to your {link_start}{link_middle}{homepage_url}dashboard{link_end} to try
-                                again, or {link_start}{homepage_url}{link_middle}contact {platform_name} Support{link_end}.
+                                If you attempted to make a purchase, you have not been charged. Return to your {link_start}{homepage_url}{link_middle}dashboard{link_end} to try
+                                again, or {link_start}{support_url}{link_middle}contact {platform_name} Support{link_end}.
                             {% endblocktrans %}
                             {% interpolate_html tmsg link_start='<a href="'|safe support_url=support_url|safe platform_name=platform_name|safe link_end='</a>'|safe homepage_url=homepage_url|safe link_middle='">'|safe %}
                         </div>


### PR DESCRIPTION
## Description

This PR was created in order to correct the bug that exists with the redirection of the dashboard and support links.

- [Jira](https://edunext.atlassian.net/browse/PS2021-1334?atlOrigin=eyJpIjoiYjFkNTE0ZjM5ODY2NDYxMWE3M2RmMmUwNWQ5ODE3YzgiLCJwIjoiaiJ9)
- [Documentation](https://docs.google.com/document/d/159hr17KP74jiyiCBmTIObGa46OcwOptqU2oRLU448WY/edit?usp=sharing)
- Juniper PR #61 

## How to test

- Ecommerce

In `<link-ecommerce>/basket `
(example: http://ecommerce.limonero.edunext.link:8130/basket/ in stack-builder local)
![Screenshot from 2021-12-23 12-15-03](https://user-images.githubusercontent.com/35668326/147267272-baf5f649-407f-4b67-9451-71001ccca20c.png)


The first link in info is dashboard link (example http://lms.limonero.edunext.link:8000/ )
And the second is support link (example: http://ecommerce.limonero.edunext.link:8130/basket/ )