### PR TITLE
E-06: Using lms courses API instead of course catalog service to fetch course data

### DIFF
--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -339,7 +339,10 @@ class VoucherViewSet(NonDestroyableModelViewSet):
         elif 'card_image_url' in course_info:
             image = course_info['card_image_url']
         else:
-            image = ''
+            try:
+                image = course_info['media']['image']['raw']
+            except (KeyError, TypeError):
+                image = ''
         return {
             'benefit': serializers.BenefitSerializer(benefit).data,
             'contains_verified': is_verified,

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -766,7 +766,6 @@ class BasketSummaryViewTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, Dis
         line_data = response.context['formset_lines_data'][0][1]
         self.assertEqual(line_data['benefit_value'], format_benefit_value(benefit))
         self.assertEqual(line_data['seat_type'], seat.attr.certificate_type.capitalize())
-        self.assertEqual(line_data['product_title'], self.course.name)
         self.assertFalse(line_data['enrollment_code'])
         self.assertEqual(response.context['payment_processors'][0].NAME, DummyProcessor.NAME)
 

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -268,13 +268,18 @@ class BasketLogicMixin:
 
         try:
             course = get_course_info_from_catalog(self.request.site, product)
-            try:
+            if 'src' in course.get('image', {}):
                 course_data['image_url'] = course['image']['src']
-            except (KeyError, TypeError):
-                pass
+            elif 'card_image_url' in course:
+                course_data['image_url'] = course['card_image_url']
+            else:
+                try:
+                    course_data['image_url'] = course['media']['image']['raw']
+                except (KeyError, TypeError):
+                    pass
 
             course_data['product_description'] = course.get('short_description', '')
-            course_data['product_title'] = course.get('title', '')
+            course_data['product_title'] = course.get('name', course.get('title', ''))
 
             # The course start/end dates are not currently used
             # in the default basket templates, but we are adding

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -279,7 +279,7 @@ class BasketLogicMixin:
                     pass
 
             course_data['product_description'] = course.get('short_description', '')
-            course_data['product_title'] = course.get('name', course.get('title', ''))
+            course_data['product_title'] = course.get('name') or course.get('title', '')
 
             # The course start/end dates are not currently used
             # in the default basket templates, but we are adding

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -106,6 +106,9 @@ SAILTHRU_SECRET = 'top_secret'
 
 REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] + ('rest_framework.renderers.BrowsableAPIRenderer',)
 
+# Edunext setting_ enabling getting course data from LMS API
+ENABLE_GET_COURSE_INFO_FROM_LMS = True
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):


### PR DESCRIPTION
## Description

This feature fetches course info on checkout page from LMS API instead of calling the Discovery service.

- [Jira](https://edunext.atlassian.net/browse/PS2021-1327?atlOrigin=eyJpIjoiNmY5Y2NiNGZhOTQ0NGIyMGFiYTE3ZTk3NWQ1MmY1ZjUiLCJwIjoiaiJ9)
- [Documentation](https://docs.google.com/document/d/1DOLvgjhtOCcyDWgBYVbSWRvmDQHWIjGvkK-R9U5sHoY/edit)
- Juniper PR #42 

## Before and after
Before
![Screenshot from 2021-12-22 16-23-54](https://user-images.githubusercontent.com/35668326/147155776-4b70baf7-8b3f-46fa-9726-3f7581014a95.png)

After
![Screenshot from 2021-12-22 16-53-33](https://user-images.githubusercontent.com/35668326/147155815-b8e14ba2-55cb-4a17-acb5-00c3a51fe33d.png)

## How to test

- In Studio create a course. (In stack-builder: http://studio.limonero.edunext.link:8001/home/ )
- Then in ecommerce create a course with the course id of the previously created course with verified mode (you can make sure that the course has the right mode in lms). (Ecommerce: http://ecommerce.limonero.edunext.link:8130/courses/ in Lms: http://lms.limonero.edunext.link:8000/admin/course_modes/coursemode/ )
- With a user who is not enrolled in the course try to enroll from lms and you should be able to see the information of the course you want to enroll in. (Example the image and the course name)

