### PR TITLE
E-03: add payu configurations

### DIFF
--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -131,6 +131,7 @@ PAYMENT_PROCESSORS = (
     'ecommerce.extensions.payment.processors.paypal.Paypal',
     'ecommerce.extensions.payment.processors.stripe.Stripe',
     'ecommerce_extensions.payment.processors.fomopay.Fomopay',
+    'ecommerce_extensions.payment.processors.payu.Payu',
 )
 
 PAYMENT_PROCESSOR_RECEIPT_PATH = '/checkout/receipt/'


### PR DESCRIPTION
# Add Payu configurations.

## Description
This PR is based on the implementation in JE https://github.com/eduNEXT/edunext-ecommerce/pull/46/files. The difference was that the file `ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html`  didn't need to be updated cause of the new way of presenting the HTML. 
## Testing instructions
* Enroll in a course with a paid mode. (Testing in stage use a course from learner-demo because this has Payu sandbox config) https://learner-demo-edunext-co.le.edunextstage.net/courses/course-v1:demo-site+cy101+2022-t1/about
* Attempt to buy the course/mode using PayU  (the green "Checkout" button)
![payu1](https://user-images.githubusercontent.com/51926076/149025769-790f75d3-a041-42f4-8d4d-f6d19625f9a2.png)

* You will be redirected to the payment form, fill it with some fake info.
![payu2](https://user-images.githubusercontent.com/51926076/149025780-07193390-cf37-4a25-8881-18cdc38643d3.png)


* Proceed with the payment and you will be redirected to the e-commerce confirmation page.
![payu4](https://user-images.githubusercontent.com/51926076/149025797-c184b6fb-c798-403a-a172-a270d6819451.png)


* Check in the tables in the stage environment that your pay info was registered. 
``` sql
use e-commerce;
```
![payu5](https://user-images.githubusercontent.com/51926076/149025809-f8bb286b-d514-4be2-95b8-6163af763a9a.png)


**extra**: 
- (cherry picked from commit 7c69edba0d55faa6a1bf2ab8c84da783ac228132)
- Jira: https://edunext.atlassian.net/browse/PS2021-1326?atlOrigin=eyJpIjoiZGZhYzRkZTBmZWY2NGViY2I4ZDI0NDgyOTE2NDE5NzkiLCJwIjoiaiJ9
## Checklist for Merge
- [x] Tested in local environment: stackbuilder  limonero local.
- [x] Tested in a remote environment: lilac stage
- [ ] Rebased limonero.master
- [ ] Squashed commits