### PR TITLE
E-12: add edupay configurable payment processor

### DIFF
--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -132,6 +132,7 @@ PAYMENT_PROCESSORS = (
     'ecommerce.extensions.payment.processors.stripe.Stripe',
     'ecommerce_extensions.payment.processors.fomopay.Fomopay',
     'ecommerce_extensions.payment.processors.payu.Payu',
+    'ecommerce_extensions.payment.processors.edupay.EdnxPaymentProcessor',
 )
 
 PAYMENT_PROCESSOR_RECEIPT_PATH = '/checkout/receipt/'


### PR DESCRIPTION
## _Description_
This PR add edupay configurable payment processor
## _Supporting information_
[PR applied][ed1]

[ed1]: <https://github.com/eduNEXT/edunext-ecommerce/pull/50>
## _Testing instruction_
Currently we don't have a sandbox to perform the testing. At the very least the QR view is visible in stage.

Is possible to mock the processor behavior based on previous successful responses we have logged using a simple flask app.

I used this code: https://gist.github.com/JuanDavidBuitrago/ed081439c017c7ab1d5d469feec70f9c and changed the [`payment_page_url`](https://github.com/eduNEXT/ecommerce-extensions/blob/752a272e28b9a6e38c55442eaef1414d6e21a858/ecommerce_extensions/payment/processors/edupay.py#L183) to point to my local flask app. The `<api-key>` is a secret value shared between the ecommerce service and the Payment Processor, make sure it's the same between the payment processor configuration and the flask app.